### PR TITLE
Default GCP service account secret for registry storage

### DIFF
--- a/astronomer.tf
+++ b/astronomer.tf
@@ -10,7 +10,7 @@ resource "null_resource" "helm_repo" {
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when = "destroy"
     command = "rm -rf './helm.astronomer.io'"
   }
 }
@@ -18,11 +18,11 @@ resource "null_resource" "helm_repo" {
 # this is for development use
 resource "helm_release" "astronomer_local" {
   depends_on = ["null_resource.helm_repo"]
-  name      = "astronomer"
-  version   = var.astronomer_version
-  chart     = "./helm.astronomer.io"
+  name = "astronomer"
+  version = var.astronomer_version
+  chart = "./helm.astronomer.io"
   namespace = var.astronomer_namespace
-  wait      = true
+  wait = true
   values = [local.astronomer_values]
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -45,21 +45,22 @@ astronomer:
 %{if var.enable_gvisor == "true"}
   houston:
     config:
-      helm:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: "sandbox.gke.io/runtime"
-                  operator: In
-                  values:
-                  - "gvisor"
-        tolerations:
-        - effect: NoSchedule
-          key: sandbox.gke.io/runtime
-          operator: Equal
-          value: gvisor
+      deployments:
+        helm:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: "sandbox.gke.io/runtime"
+                    operator: In
+                    values:
+                    - "gvisor"
+          tolerations:
+          - effect: NoSchedule
+            key: sandbox.gke.io/runtime
+            operator: Equal
+            value: gvisor
 %{endif}
 %{if var.gcp_default_service_account_key != ""}
   registry:

--- a/secrets.tf
+++ b/secrets.tf
@@ -25,3 +25,17 @@ resource "kubernetes_secret" "astronomer_tls" {
     "tls.key" = var.tls_key
   }
 }
+
+resource "kubernetes_secret" "astronomer-gcs-keyfile" {
+  count = var.gcp_default_service_account_key != "" ? 1 : 0
+  metadata {
+    name      = "astronomer-gcs-keyfile"
+    namespace = var.astronomer_namespace
+  }
+
+  type = "kubernetes.io/generic"
+
+  data = {
+    "astronomer-gcs-keyfile" = var.gcp_default_service_account_key
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "cluster_type" {
-  type        = string
+  type = string
 }
 
 variable "db_connection_string" {
@@ -42,18 +42,26 @@ variable "load_balancer_ip" {
 }
 
 variable "astronomer_namespace" {
-  default     = "astronomer"
-  type        = string
+  default = "astronomer"
+  type    = string
 }
 
 variable "enable_istio" {
-  default     = "false"
-  type        = string
+  default = "false"
+  type    = string
 }
 
 variable "enable_gvisor" {
-  default     = "false"
-  type        = string
+  default = "false"
+  type    = string
 }
 
+variable "gcp_default_service_account_key" {
+  default = ""
+  type    = string
+}
 
+variable "container_registry_bucket_name" {
+  default = ""
+  type    = string
+}


### PR DESCRIPTION
* Part 2/3(?)
* Add Kubernetes secret for default GCP service account
  * Necessary for GCS registry back end
* Add variable for default GCP service account key
* Add variable for GCS bucket name
* Some files changed after `terraform fmt`
* Related to astronomer/biz-cloud#72