### PR TITLE
Install from Helm repository by default

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,8 +38,6 @@ steps:
   when:
     event:
       - push
-    branch:
-      - master
 
 - name: terraform_destroy
   image: sjmiller609/helm-kubectl-terraform:latest
@@ -56,8 +54,6 @@ steps:
     status:
       - failure
       - success
-    branch:
-      - master
 
 - name: git_tag
   image: docker:git

--- a/astronomer.tf
+++ b/astronomer.tf
@@ -3,19 +3,19 @@ resource "random_id" "collision_avoidance" {
 }
 
 resource "null_resource" "helm_repo" {
+  count = var.astronomer_chart_git_repository == "" ? 0 : 1
 
   provisioner "local-exec" {
     command = <<EOF
     set -xe
-    export directory=/tmp/astronomer-${var.astronomer_version}-${random_id.collision_avoidance.hex}
+    export directory=/tmp/astronomer-${var.astronomer_version_git_checkout}-${random_id.collision_avoidance.hex}
     rm -rf $directory
     mkdir -p $directory
     cd $directory
-    git clone https://github.com/astronomer/helm.astronomer.io.git
-    if [ ${var.astronomer_version} != "master" ]; then
-      cd helm.astronomer.io
-      git checkout v${var.astronomer_version}
-    fi
+    git clone ${var.astronomer_chart_git_respository}
+    mv * astronomer
+    cd astronomer
+    git checkout ${var.astronomer_version_git_checkout}
     EOF
   }
 
@@ -24,37 +24,41 @@ resource "null_resource" "helm_repo" {
   }
 }
 
-# this is for development use
-resource "helm_release" "astronomer_local" {
+resource "helm_release" "astronomer_with_git_clone" {
+  count = var.astronomer_chart_git_repository == "" ? 0 : 1
+
   depends_on = [null_resource.helm_repo,
     null_resource.dependency_getter,
     kubernetes_secret.astronomer_bootstrap,
   kubernetes_secret.astronomer_tls]
 
   name      = "astronomer"
-  version   = var.astronomer_version
-  chart     = "/tmp/astronomer-${var.astronomer_version}-${random_id.collision_avoidance.hex}/helm.astronomer.io"
+  chart     = "/tmp/astronomer-${var.astronomer_version_git_checkout}-${random_id.collision_avoidance.hex}/astronomer"
   namespace = var.astronomer_namespace
-  wait      = true
+  wait      = var.wait_for_helm_chart
   timeout   = 900
   values    = [var.astronomer_helm_values]
 }
 
-/*
 data "helm_repository" "astronomer_repo" {
-  name       = var.astronomer_namespace
-  url        = "https://helm.astronomer.io/"
+  url  = var.astronomer_helm_chart_repo_url
+  name = var.astronomer_helm_chart_repo
 }
-
 
 resource "helm_release" "astronomer" {
-  count = var.local_umbrella_chart == "" ? 1 : 0
-  name       = "astronomer"
+  count = var.astronomer_chart_git_repository == "" ? 1 : 0
+
+  depends_on = [null_resource.helm_repo,
+    null_resource.dependency_getter,
+    kubernetes_secret.astronomer_bootstrap,
+  kubernetes_secret.astronomer_tls]
+
   version    = var.astronomer_version
-  chart      = "/tmp/astronomer-${var.astronomer_version}-${random_id.collision_avoidance.hex}"
+  name       = var.astronomer_helm_chart_name
+  chart      = var.astronomer_helm_chart_name
   repository = data.helm_repository.astronomer_repo.name
   namespace  = var.astronomer_namespace
-  wait       = true
-  values = [var.astronomer_helm_values]
+  wait       = var.wait_for_helm_chart
+  timeout    = 900
+  values     = [var.astronomer_helm_values]
 }
-*/

--- a/astronomer.tf
+++ b/astronomer.tf
@@ -12,7 +12,7 @@ resource "null_resource" "helm_repo" {
     rm -rf $directory
     mkdir -p $directory
     cd $directory
-    git clone ${var.astronomer_chart_git_respository}
+    git clone ${var.astronomer_chart_git_repository}
     mv * astronomer
     cd astronomer
     git checkout ${var.astronomer_version_git_checkout}

--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -40,6 +40,7 @@ global:
   baseDomain: ${module.aws.base_domain}
   tlsSecret: astronomer-tls
   istioEnabled: false
+  postgresqlEnabled: false
 
 nginx:
   loadBalancerIP: "~"

--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -29,7 +29,6 @@ module "system_components" {
 module "astronomer" {
   dependencies         = [module.system_components.depended_on]
   source               = "../.."
-  astronomer_version   = "0.9.2"
   db_connection_string = module.aws.db_connection_string
   tls_cert             = module.aws.tls_cert
   tls_key              = module.aws.tls_key
@@ -46,7 +45,6 @@ nginx:
   loadBalancerIP: "~"
   privateLoadBalancer: true
   perserveSourceIP: true
-
 EOF
 }
 

--- a/pipeline/run_terraform.sh
+++ b/pipeline/run_terraform.sh
@@ -19,5 +19,6 @@ cat .terraform/modules/modules.json | python -m json.tool
 if [ $DESTROY -eq 1 ]; then
   terraform destroy --auto-approve -var "deployment_id=$DEPLOYMENT_ID" -refresh=false -lock=false
 else
+  terraform apply --auto-approve -var "deployment_id=$DEPLOYMENT_ID" --target=local_file.kubeconfig
   terraform apply --auto-approve -var "deployment_id=$DEPLOYMENT_ID"
 fi

--- a/variables.tf
+++ b/variables.tf
@@ -13,14 +13,45 @@ variable "tls_key" {
   description = "The private key corresponding to the signed certificate tls_cert."
 }
 
-variable "local_umbrella_chart" {
-  default = ""
-  type    = string
+variable "astronomer_version_git_checkout" {
+  description = "Verison of the helm chart to use, when using git clone method. This should exactly match what you would want to use with 'git checkout <this variable>'. This is ignored if astronomer_chart_git_repository is not configured."
+  default     = "master"
+  type        = string
+}
+
+variable "astronomer_chart_git_repository" {
+  description = "Git repository clone url, when using git clone method. This should exactly match what you would want to use with 'git clone <this variable>'. It is better to not use this and instead use just the astronomer_version variable, which will pull from the Astronomer Helm chart repository."
+  default     = ""
+  type        = string
 }
 
 variable "astronomer_version" {
-  description = "verison of helm chart to use, do not include a 'v' at the front"
-  default     = "0.9.2"
+  description = "Verison of Helm chart to use, do not include a 'v' at the front"
+  default     = "0.12.0-alpha.1"
+  type        = string
+}
+
+variable "astronomer_helm_chart_name" {
+  description = "The name of the Astronomer Helm chart to install from the Astronomer Helm chart repository."
+  default     = "astronomer"
+  type        = string
+}
+
+variable "wait_for_helm_chart" {
+  description = "Should we wait for Astronomer to come up before indicating the apply is complete?"
+  default     = true
+  type        = bool
+}
+
+variable "astronomer_helm_chart_repo" {
+  description = "The name of the Astronomer Helm chart repo"
+  default     = "astronomer"
+  type        = string
+}
+
+variable "astronomer_helm_chart_repo_url" {
+  description = "The url of the Astronomer Helm chart repo"
+  default     = "https://helm.astronomer.io"
   type        = string
 }
 


### PR DESCRIPTION
Closes: https://github.com/astronomer/issues/issues/812

The point of this PR is to allow us to helm install astronomer using either the 'git clone' or 'helm repo add' method. The enterprise module should not be updated to use this until after we publish a stable release on the Helm chart repo, and update the default 'astronomer_version' in this module.