### PR TITLE
Fixing deprecation warning due to usage of helm_repository

### DIFF
--- a/astronomer.tf
+++ b/astronomer.tf
@@ -44,10 +44,5 @@ resource "helm_release" "astronomer_local" {
   chart = var.astronomer_chart_git_repository == "" ? var.astronomer_helm_chart_name : "/tmp/astronomer-${var.astronomer_version_git_checkout}-${random_id.collision_avoidance.hex}/astronomer"
 
   # These settings only are applied when using a Helm chart repo
-  repository = var.astronomer_chart_git_repository == "" ? data.helm_repository.astronomer_repo.name : null
-}
-
-data "helm_repository" "astronomer_repo" {
-  url  = var.astronomer_helm_chart_repo_url
-  name = var.astronomer_helm_chart_repo
+  repository = var.astronomer_chart_git_repository == "" ? var.astronomer_helm_chart_repo_url : null
 }


### PR DESCRIPTION
The helm_respository data resource has been deprecated as mentioned in https://www.terraform.io/docs/providers/helm/d/repository.html

The commit above should fix the issue.

Without the change `terraform plan` and `terraform apply` come up with the following warning:

```
Warning: This resource is deprecated and will be removed in the next major version. 
Please supply the URL of your repository to helm_release resources directly, using the repository attribute.
See: https://www.terraform.io/docs/providers/helm/r/release.html#example-usage
  on .terraform/modules/astronomer.astronomer/terraform-kubernetes-astronomer-1.1.89/astronomer.tf line 50, in data "helm_repository" "astronomer_repo":
  50: data "helm_repository" "astronomer_repo" {
```